### PR TITLE
fix: inline source code in esm map files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist/esm",
+    "inlineSources": true,
     "pretty": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
This is necessary like in other plugins, e.g. https://github.com/capacitor-community/keep-awake/blob/master/CHANGELOG.md#211-2022-01-26