### PR TITLE
docs: Document -1 value

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ Returns info than contains the current brightness level
 
 #### SetBrightnessOptions
 
-| Prop             | Type                | Description                                                                      | Since |
-| ---------------- | ------------------- | -------------------------------------------------------------------------------- | ----- |
-| **`brightness`** | <code>number</code> | The level to set the brightness to, from 0.0 (very dim) to 1.0 (full brightness) | 1.0.0 |
+| Prop             | Type                | Description                                                                                                                                                   | Since |
+| ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`brightness`** | <code>number</code> | The level to set the brightness to, from 0.0 (very dim) to 1.0 (full brightness) On Android, setting the value to -1 restores the user configured brightness. | 1.0.0 |
 
 
 #### GetBrightnessReturnValue
 
-| Prop             | Type                | Description                                                                | Since |
-| ---------------- | ------------------- | -------------------------------------------------------------------------- | ----- |
-| **`brightness`** | <code>number</code> | The current brightness level, from 0.0 (very dim) to 1.0 (full brightness) | 1.0.0 |
+| Prop             | Type                | Description                                                                                                                                       | Since |
+| ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`brightness`** | <code>number</code> | The current brightness level, from 0.0 (very dim) to 1.0 (full brightness) On Android it returns -1 if the value has not been changed by the app. | 1.0.0 |
 
 </docgen-api>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,6 +16,9 @@ export interface SetBrightnessOptions {
   /**
    * The level to set the brightness to,
    * from 0.0 (very dim) to 1.0 (full brightness)
+   *
+   * On Android, setting the value to -1 restores the user configured brightness.
+   *
    * @since 1.0.0
    */
   brightness: number;
@@ -24,6 +27,9 @@ export interface SetBrightnessOptions {
 export interface GetBrightnessReturnValue {
   /**
    * The current brightness level, from 0.0 (very dim) to 1.0 (full brightness)
+   *
+   * On Android it returns -1 if the value has not been changed by the app.
+   *
    * @since 1.0.0
    */
   brightness: number;


### PR DESCRIPTION
Document that on Android it will return -1 if the brightness has not been set by the app, and -1 can also be used to restore the user configured brightness instead of the app configured brightness

closes https://github.com/capacitor-community/screen-brightness/issues/3