### PR TITLE
docs(README): remove maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
-## Maintainers
-
-| Maintainer | GitHub | Social |
-| -----------| -------| -------|
-| Ely Lucas | [elylucas](https://github.com/elylucas) | [@elylucas](https://twitter.com/elylucas) |
-
 ## Versions
 
 | Plugin | Capacitor | Documentation                                                                     |


### PR DESCRIPTION
The maintainer has not been around for 4 years, so remove them so they don't get pinged by people.